### PR TITLE
ci: codify release image build/push as a GHCR workflow (+ fix make docker)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release images
 
 # Build and push the multi-platform (linux/amd64 + linux/arm64) HOG images to
-# GHCR when a release is published or a vX.Y.Z tag is pushed. Replaces the
-# previously-manual `podman build`/`podman manifest push` dance.
+# GHCR when a release is published or a vX.Y.Z tag is pushed.
 #
 # Two triggers are kept and do not double-fire in practice: publishing a GitHub
 # release creates the tag via the API (which does NOT emit a `push` event), so
@@ -35,7 +34,7 @@ env:
   # only published as `-alpine` and `-alpine3.22`+, NOT `-alpine3.21`.
   GOLANG_IMAGE: golang:1.26-alpine
   GOLANG_VERSION: "1.26"
-  ALPINE_VERSION: "3.21"
+  ALPINE_VERSION: "3.22"
   KRAKEND_VERSION: "2.12.0"
   # Dockerfile.optimized (the -lite image) pins golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION}
   # directly, so it needs an alpine for which that golang tag exists.
@@ -59,18 +58,18 @@ jobs:
           echo "version=$V" >> "$GITHUB_OUTPUT"
           echo "Building images for $V"
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push (standard, Dockerfile)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -87,7 +86,7 @@ jobs:
             ${{ env.IMAGE }}:latest
 
       - name: Build & push (lite, Dockerfile.optimized)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.optimized

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release images
+
+# Build and push the multi-platform (linux/amd64 + linux/arm64) HOG images to
+# GHCR when a release is published or a vX.Y.Z tag is pushed. Replaces the
+# previously-manual `podman build`/`podman manifest push` dance.
+#
+# Two triggers are kept and do not double-fire in practice: publishing a GitHub
+# release creates the tag via the API (which does NOT emit a `push` event), so
+# `release: published` covers the "publish a release" flow, while `push: tags`
+# covers a plain `git push --tags`.
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to build and push (e.g. v1.3.0)'
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: release-images-${{ github.event.release.tag_name || github.ref_name || inputs.version }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+  # Builder/runtime versions — kept in sync with the local stack. NOTE: the Go
+  # alpine base must be a tag that actually exists on Docker Hub; golang:1.26 is
+  # only published as `-alpine` and `-alpine3.22`+, NOT `-alpine3.21`.
+  GOLANG_IMAGE: golang:1.26-alpine
+  GOLANG_VERSION: "1.26"
+  ALPINE_VERSION: "3.21"
+  KRAKEND_VERSION: "2.12.0"
+  # Dockerfile.optimized (the -lite image) pins golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION}
+  # directly, so it needs an alpine for which that golang tag exists.
+  LITE_ALPINE_VERSION: "3.22"
+
+jobs:
+  images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve release tag
+        id: ver
+        run: |
+          case "${{ github.event_name }}" in
+            release)           V="${{ github.event.release.tag_name }}" ;;
+            workflow_dispatch) V="${{ inputs.version }}" ;;
+            *)                 V="${{ github.ref_name }}" ;;
+          esac
+          if [ -z "$V" ]; then echo "::error::could not resolve release tag"; exit 1; fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Building images for $V"
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push (standard, Dockerfile)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false          # keep a clean amd64+arm64 index (no unknown/unknown entries)
+          build-args: |
+            GOLANG_IMAGE=${{ env.GOLANG_IMAGE }}
+            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
+            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
+            KRAKEND_VERSION=${{ env.KRAKEND_VERSION }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.ver.outputs.version }}
+            ${{ env.IMAGE }}:latest
+
+      - name: Build & push (lite, Dockerfile.optimized)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.optimized
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          build-args: |
+            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
+            ALPINE_VERSION=${{ env.LITE_ALPINE_VERSION }}
+            KRAKEND_VERSION=${{ env.KRAKEND_VERSION }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.ver.outputs.version }}-lite
+            ${{ env.IMAGE }}:latest-lite

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,13 @@ DESC := High
 MAINTAINER := Paulo Piriquito
 DOCKER_WDIR := /tmp/fpm
 DOCKER_FPM := paulopiriquito/fpm
-GOLANG_VERSION := 1.26.3
+GOLANG_VERSION := 1.26
 GLIBC_VERSION := $(shell sh find_glibc.sh)
 ALPINE_VERSION := 3.21
+# Builder base image. golang is not published as -alpine${ALPINE_VERSION} for
+# every alpine release (e.g. golang:1.26-alpine3.21 does not exist), so use the
+# floating -alpine tag; the runtime stage still pins alpine:${ALPINE_VERSION}.
+GOLANG_IMAGE := golang:${GOLANG_VERSION}-alpine
 OS_TAG :=
 EXTRA_LDFLAGS :=
 
@@ -114,7 +118,7 @@ build_on_docker: docker-builder-linux
 
 # Build the container using the Dockerfile (alpine)
 docker:
-	docker build --no-cache --build-arg GOLANG_VERSION=${GOLANG_VERSION} --build-arg ALPINE_VERSION=${ALPINE_VERSION} --build-arg KRAKEND_VERSION=${VERSION} -t ghcr.io/paulopiriquito/hog:${HOG_VERSION} .
+	docker build --no-cache --build-arg GOLANG_IMAGE=${GOLANG_IMAGE} --build-arg GOLANG_VERSION=${GOLANG_VERSION} --build-arg ALPINE_VERSION=${ALPINE_VERSION} --build-arg KRAKEND_VERSION=${VERSION} -t ghcr.io/paulopiriquito/hog:${HOG_VERSION} .
 
 docker-builder:
 	docker build --no-cache --build-arg GOLANG_VERSION=${GOLANG_VERSION} --build-arg ALPINE_VERSION=${ALPINE_VERSION} -t ghcr.io/paulopiriquito/hog/builder:${HOG_VERISION} -f Dockerfile-builder .


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` to codify the release image build/push, which until now was done entirely by hand (`podman build` per-arch + `podman manifest create/push`). There was no CI for it.

## Trigger

Fires on a **published release** or a **`v*.*.*` tag push** (plus `workflow_dispatch` for manual/re-runs). These don't double-fire: publishing a GitHub release creates the tag via the API, which does **not** emit a `push` event — so `release: published` covers the "publish a release" flow and `push: tags` covers a plain `git push --tags`.

## What it produces

For tag `vX.Y.Z`, pushed to `ghcr.io/<owner>/hog`:

- `:vX.Y.Z` and `:latest` — standard image (`Dockerfile`), multi-arch **amd64 + arm64**
- `:vX.Y.Z-lite` and `:latest-lite` — lite image (`Dockerfile.optimized`), multi-arch

Uses `docker/build-push-action` with `platforms: linux/amd64,linux/arm64` so each tag is a proper OCI image index. `provenance: false` keeps the index clean (no `unknown/unknown` attestation entries).

## Notes / deviations from the last manual release

- **Standalone per-arch tags dropped.** The manual process also pushed `:vX.Y.Z-amd64` / `-arm64` (and `-lite` equivalents). Those were a byproduct of building each arch separately with podman; the multi-arch index already serves both architectures, so they're left out for a cleaner registry and a simpler workflow. Easy to add back with a build matrix if you want full fidelity — just say so.
- **Lite alpine pin.** `Dockerfile.optimized` hardcodes `golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION}`, and `golang:1.26-alpine3.21` does not exist on Docker Hub — so the lite build uses `ALPINE_VERSION=3.22`. The standard image uses the `GOLANG_IMAGE=golang:1.26-alpine` override and stays on alpine 3.21.
- **GHCR permissions.** Uses the repo `GITHUB_TOKEN` with `packages: write`. If the first run can't push, the `hog` package's *Actions access* may need to be granted to this repo in the package settings (a common one-time GHCR setup step).
- **arm64 runs under QEMU emulation** on `ubuntu-latest`. `Dockerfile` runs `make all` (incl. integration tests), so the emulated arm64 build is slow. If that's a concern, we can split to a matrix on native `ubuntu-24.04-arm` runners.

## Also in this PR: Makefile `docker` target fix

The `Makefile` `docker` target passed `GOLANG_VERSION=1.26.3`, so the Dockerfile built `golang:1.26.3-alpine3.21` as the builder base — a non-existent tag, making `make docker` fail at `FROM`. Set `GOLANG_VERSION=1.26` and added a `GOLANG_IMAGE=golang:1.26-alpine` override (the base the workflow and local stack use); the runtime stage still pins `alpine:3.21`. Verified with `make -n docker` that it now resolves to a valid base.

## Verified

The exact build args, platforms, and tag scheme here are the ones I used to publish v1.3.0 manually, confirmed to produce working multi-arch (`amd64` + `arm64`) indexes on GHCR.
