### PR TITLE
ci: build release images on native per-arch runners (no QEMU)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release images
 # Build and push the multi-platform (linux/amd64 + linux/arm64) HOG images to
 # GHCR when a release is published or a vX.Y.Z tag is pushed.
 #
+# Each architecture is built on its own NATIVE runner (amd64 on ubuntu-latest,
+# arm64 on ubuntu-24.04-arm) — no QEMU emulation, which made the previous
+# single-job multi-arch build hang on the arm64 `make all` step. A final job
+# stitches the per-arch images into multi-arch manifests.
+#
 # Two triggers are kept and do not double-fire in practice: publishing a GitHub
 # release creates the tag via the API (which does NOT emit a `push` event), so
 # `release: published` covers the "publish a release" flow, while `push: tags`
@@ -24,79 +29,88 @@ permissions:
   packages: write
 
 concurrency:
-  group: release-images-${{ github.event.release.tag_name || github.ref_name || inputs.version }}
+  group: release-images-${{ github.event.release.tag_name || github.ref_name }}
   cancel-in-progress: false
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}
-  # Builder/runtime versions — kept in sync with the local stack. NOTE: the Go
-  # alpine base must be a tag that actually exists on Docker Hub; golang:1.26 is
-  # only published as `-alpine` and `-alpine3.22`+, NOT `-alpine3.21`.
-  GOLANG_IMAGE: golang:1.26-alpine
-  GOLANG_VERSION: "1.26"
-  ALPINE_VERSION: "3.22"
-  KRAKEND_VERSION: "2.12.0"
-  # Dockerfile.optimized (the -lite image) pins golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION}
-  # directly, so it needs an alpine for which that golang tag exists.
-  LITE_ALPINE_VERSION: "3.22"
 
 jobs:
-  images:
+  version:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.v.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Resolve release tag
-        id: ver
+      - id: v
         run: |
           case "${{ github.event_name }}" in
-            release)           V="${{ github.event.release.tag_name }}" ;;
-            workflow_dispatch) V="${{ inputs.version }}" ;;
-            *)                 V="${{ github.ref_name }}" ;;
+            release)           T="${{ github.event.release.tag_name }}" ;;
+            workflow_dispatch) T="${{ inputs.version }}" ;;
+            *)                 T="${{ github.ref_name }}" ;;
           esac
-          if [ -z "$V" ]; then echo "::error::could not resolve release tag"; exit 1; fi
-          echo "version=$V" >> "$GITHUB_OUTPUT"
-          echo "Building images for $V"
+          [ -n "$T" ] || { echo "::error::could not resolve release tag"; exit 1; }
+          echo "tag=$T" >> "$GITHUB_OUTPUT"
+          echo "Building images for $T"
 
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
+  build:
+    needs: version
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # standard image (Dockerfile) — builder golang:1.26-alpine, runtime alpine:3.21
+          - { suffix: "",      file: Dockerfile,           alpine: "3.21", arch: amd64, runner: ubuntu-latest }
+          - { suffix: "",      file: Dockerfile,           alpine: "3.21", arch: arm64, runner: ubuntu-24.04-arm }
+          # lite image (Dockerfile.optimized) — golang:1.26-alpine3.22 / alpine:3.22
+          # (golang:1.26-alpine3.21 is not published, so the lite variant uses 3.22)
+          - { suffix: "-lite", file: Dockerfile.optimized, alpine: "3.22", arch: amd64, runner: ubuntu-latest }
+          - { suffix: "-lite", file: Dockerfile.optimized, alpine: "3.22", arch: arm64, runner: ubuntu-24.04-arm }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & push (standard, Dockerfile)
-        uses: docker/build-push-action@v7
+      - name: Build & push ${{ matrix.arch }}${{ matrix.suffix }}
+        uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          provenance: false          # keep a clean amd64+arm64 index (no unknown/unknown entries)
-          build-args: |
-            GOLANG_IMAGE=${{ env.GOLANG_IMAGE }}
-            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
-            ALPINE_VERSION=${{ env.ALPINE_VERSION }}
-            KRAKEND_VERSION=${{ env.KRAKEND_VERSION }}
-          tags: |
-            ${{ env.IMAGE }}:${{ steps.ver.outputs.version }}
-            ${{ env.IMAGE }}:latest
-
-      - name: Build & push (lite, Dockerfile.optimized)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile.optimized
-          platforms: linux/amd64,linux/arm64
+          file: ${{ matrix.file }}
+          platforms: linux/${{ matrix.arch }}
           push: true
           provenance: false
           build-args: |
-            GOLANG_VERSION=${{ env.GOLANG_VERSION }}
-            ALPINE_VERSION=${{ env.LITE_ALPINE_VERSION }}
-            KRAKEND_VERSION=${{ env.KRAKEND_VERSION }}
-          tags: |
-            ${{ env.IMAGE }}:${{ steps.ver.outputs.version }}-lite
-            ${{ env.IMAGE }}:latest-lite
+            GOLANG_IMAGE=golang:1.26-alpine
+            GOLANG_VERSION=1.26
+            ALPINE_VERSION=${{ matrix.alpine }}
+            KRAKEND_VERSION=2.12.0
+          tags: ${{ env.IMAGE }}:${{ needs.version.outputs.tag }}-${{ matrix.arch }}${{ matrix.suffix }}
+
+  manifest:
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { suffix: "",      latest: latest }
+          - { suffix: "-lite", latest: latest-lite }
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest${{ matrix.suffix }}
+        env:
+          TAG: ${{ needs.version.outputs.tag }}
+        run: |
+          docker buildx imagetools create \
+            -t "${IMAGE}:${TAG}${{ matrix.suffix }}" \
+            -t "${IMAGE}:${{ matrix.latest }}" \
+            "${IMAGE}:${TAG}-amd64${{ matrix.suffix }}" \
+            "${IMAGE}:${TAG}-arm64${{ matrix.suffix }}"
+          docker buildx imagetools inspect "${IMAGE}:${TAG}${{ matrix.suffix }}"


### PR DESCRIPTION
## Problem

The release workflow (from #25) built both architectures in one job with `docker/build-push-action` + QEMU. The arm64 half emulates an x86 host running the `Dockerfile`'s `RUN make all` — which compiles KrakenD, builds the cgo plugin `.so`s, and runs the KrakenD-CE integration suite (forking the gateway binary). Under emulation that's brutally slow; a `workflow_dispatch` run sat on the "Build & push (standard)" step for **35+ minutes** with no end in sight ([example](https://github.com/paulopiriquito/hog/actions/runs/27449669363)). I cancelled it.

This is exactly the emulation risk flagged in #25 — now fixed.

## Fix

Build each architecture on its **own native runner** — no QEMU:

- `version` job resolves the tag once.
- `build` matrix (4 jobs): `{standard, lite} × {amd64, arm64}`, with `arch=amd64 → ubuntu-latest` and `arch=arm64 → ubuntu-24.04-arm` (GitHub's native arm64 runners, free for public repos). Each builds single-platform and pushes a per-arch tag (`:<tag>-<arch>` / `:<tag>-<arch>-lite`).
- `manifest` matrix (2 jobs): stitches the per-arch tags into multi-arch manifests with `docker buildx imagetools create`, tagging `:<tag>` / `:latest` and `:<tag>-lite` / `:latest-lite`, then inspects the result.

## What it produces (full scheme, restored)

`:<tag>` · `:<tag>-amd64` · `:<tag>-arm64` · `:<tag>-lite` · `:<tag>-amd64-lite` · `:<tag>-arm64-lite` · `:latest` · `:latest-lite`

This also brings back the standalone per-arch tags that the first version dropped — and it's fast, since every build runs natively.

## Notes

- Triggers, permissions, and the version-resolution logic are unchanged.
- `:latest`/`:latest-lite` are always moved to the built tag; if you ever re-run for an older release, add a guard.
